### PR TITLE
Adding support for the wood_types mod

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = moretrees
 depends = default, biome_lib, vessels
-optional_depends = doors, stairs, moreblocks, farming
+optional_depends = doors, stairs, moreblocks, farming, wood_types
 min_minetest_version = 5.2.0

--- a/node_defs.lua
+++ b/node_defs.lua
@@ -292,6 +292,15 @@ for i in ipairs(moretrees.treelist) do
 			sounds = default.node_sound_wood_defaults(),
 		})
 
+		-- Register this wood type with the `wood_types` mod, so all mods can easily use it automatically
+		if minetest.get_modpath("wood_types") then
+			wood_types.register_wood(
+				"moretrees:"..treename.."_planks",
+				treename,
+				moretrees.treedesc[treename].planks,
+				{"moretrees_"..treename.."_wood.png"})
+		end
+
 		minetest.register_node("moretrees:"..treename.."_sapling", {
 			description = moretrees.treedesc[treename].sapling,
 			drawtype = "plantlike",


### PR DESCRIPTION
Hi,

This PR is mostly to get feedback on a new mod idea I've created which should massively simplify how different mods that provide types of wood, and items made of wood (by which I mean, items that have a different texture depending on the type of wood they were made from), work together. The idea is to take the current many-to-many relationship where each mod that adds wooden items needs to be aware of and check the presence of every mod that adds wood types to the game, and replace it with a single point that each mod interacts with.

This mod hasn't been submitted to ContentDB yet as I'd prefer some feedback on the idea first.

This is the mod: https://github.com/JordanL2/wood_types

The readme should describe the idea and approach pretty well, by all means ask me any questions if anything is unclear. 

As an example, here is a commit showing how a wooden-item-providing mod, such as `gates_long` which adds a new type of wooden gate, can be massively simplified:
https://github.com/JordanL2/gates_long/commit/0d52b39ef40e82bcf56d749cd4fc32d1d4caa8c8

If feedback is positive, my next steps will be to submit this mod to ContentDB, then get support added to the various mods that add wood types such as this mod and EtherealNG, then add support to the various mods that add wooden items such as `ts_furniture`.