### PR TITLE
Remove unused optional dep to avoid circular dep

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -14,6 +14,7 @@ globals = {
 	"default",
 	"dump",
 	"moretrees",
+	"ethereal",
 }
 
 read_globals = {

--- a/init.lua
+++ b/init.lua
@@ -62,6 +62,20 @@ if io.open(worldpath.."/moretrees_settings.txt","r") then
 	dofile(worldpath.."/moretrees_settings.txt")
 end
 
+-- Validate that if ethereal exists, that it's version is greater than 20220424.
+-- Lower versions of ethereal clear registered biomes and decorations during
+-- initialization which results in lost content from this mod (and others)
+-- depending on where they are in the mod load order.
+minetest.register_on_mods_loaded(function()
+	if minetest.global_exists("ethereal") then
+		local ethereal_ver = tonumber(ethereal.version)
+		if (ethereal_ver and ethereal_ver < 20220424) then
+			error("[moretrees] The version of ethereal detected can result " ..
+				  "in parts of this mod and others disappearing due to mod " ..
+				  "load order. Please update ethereal.");
+		end
+	end
+end)
 
 -- infinite stacks checking
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = moretrees
 depends = default, vessels
-optional_depends = doors, stairs, moreblocks, farming, ethereal
+optional_depends = doors, stairs, moreblocks, farming
 min_minetest_version = 5.2.0


### PR DESCRIPTION
Removing `ethereal` from the `optional_depends` because it is not used in moretrees and it creates a circular dependency.

The dependency cycle this solves is currently ethereal --> bakedclay --> flowerpot --> moretrees --> ethereal.