### PR TITLE
Player placed fruits have param2 set to 1

### DIFF
--- a/node_defs.lua
+++ b/node_defs.lua
@@ -542,6 +542,11 @@ for i in ipairs(moretrees.treelist) do
 				},
 			groups = {fleshy=3,dig_immediate=3,flammable=2, attached_node=1, leafdecay = 1, leafdecay_drop = 1},
 			sounds = default.node_sound_defaults(),
+			after_place_node = function(pos, placer)
+				if placer:is_player() then
+					minetest.set_node(pos, {name = "moretrees:"..fruit, param2 = 1})
+				end
+			end
 		})
 	end
 


### PR DESCRIPTION
Player placed fruits have their param2 set to 1 for any mods that need to know if it was grown by sapling or placed by player.