### PR TITLE
remove `biome_lib` dependency from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ jungle trees mod, and big contributions by RealBadAngel.
 Brought together into one mod and made L-systems compatible by Vanessa
 Ezekowitz.
 
-Dependencies: <a href="https://forum.minetest.net/viewtopic.php?f=11&t=12999">biome_lib</a> and default
+Dependencies: `default`


### PR DESCRIPTION
fixes #30 

The line could alternatively be removed entirely IMO, the dependency info is either visible in the cdb or the `mod.conf` anyway