### PR TITLE
Add setting to disable tree specific plank variants

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -3,13 +3,15 @@ local S = minetest.get_translator("moretrees")
 for i in ipairs(moretrees.treelist) do
 	local treename = moretrees.treelist[i][1]
 
-	minetest.register_craft({
-		type = "shapeless",
-		output = "moretrees:"..treename.."_planks 4",
-		recipe = {
-			"moretrees:"..treename.."_trunk"
-		}
-	})
+	if moretrees.enable_planks then
+		minetest.register_craft({
+			type = "shapeless",
+			output = "moretrees:"..treename.."_planks 4",
+			recipe = {
+				"moretrees:"..treename.."_trunk"
+			}
+		})
+	end
 
 	minetest.register_craft({
 		type = "fuel",

--- a/node_defs.lua
+++ b/node_defs.lua
@@ -284,13 +284,15 @@ for i in ipairs(moretrees.treelist) do
 			on_place = minetest.rotate_node,
 		})
 
-		minetest.register_node("moretrees:"..treename.."_planks", {
-			description = moretrees.treedesc[treename].planks,
-			tiles = {"moretrees_"..treename.."_wood.png"},
-			is_ground_content = false,
-			groups = {snappy=1,choppy=2,oddly_breakable_by_hand=2,flammable=3,wood=1},
-			sounds = default.node_sound_wood_defaults(),
-		})
+		if moretrees.enable_planks then
+			minetest.register_node("moretrees:"..treename.."_planks", {
+				description = moretrees.treedesc[treename].planks,
+				tiles = {"moretrees_"..treename.."_wood.png"},
+				is_ground_content = false,
+				groups = {snappy=1,choppy=2,oddly_breakable_by_hand=2,flammable=3,wood=1},
+				sounds = default.node_sound_wood_defaults(),
+			})
+		end
 
 		local moretrees_leaves_inventory_image = nil
 		local moretrees_new_leaves_waving = nil
@@ -343,17 +345,19 @@ for i in ipairs(moretrees.treelist) do
 					}
 				)
 
-				stairsplus:register_all(
-					"moretrees",
-					treename.."_planks",
-					"moretrees:"..treename.."_planks",
-					{
-						groups = { snappy=1, choppy=2, oddly_breakable_by_hand=2, flammable=3, not_in_creative_inventory=1 },
-						tiles = { "moretrees_"..treename.."_wood.png" },
-						description = moretrees.treedesc[treename].planks,
-						drop = treename.."_planks",
-					}
-				)
+				if moretrees.enable_planks then
+					stairsplus:register_all(
+						"moretrees",
+						treename.."_planks",
+						"moretrees:"..treename.."_planks",
+						{
+							groups = { snappy=1, choppy=2, oddly_breakable_by_hand=2, flammable=3, not_in_creative_inventory=1 },
+							tiles = { "moretrees_"..treename.."_wood.png" },
+							description = moretrees.treedesc[treename].planks,
+							drop = treename.."_planks",
+						}
+					)
+				end
 			elseif minetest.get_modpath("stairs") then
 				stairs.register_stair_and_slab(
 					"moretrees_"..treename.."_trunk",
@@ -368,20 +372,22 @@ for i in ipairs(moretrees.treelist) do
 					default.node_sound_wood_defaults()
 				)
 
-				stairs.register_stair_and_slab(
-					"moretrees_"..treename.."_planks",
-					"moretrees:"..treename.."_planks",
-					{ snappy=1, choppy=2, oddly_breakable_by_hand=2, flammable=3 },
-					{ "moretrees_"..treename.."_wood.png" },
-					moretrees.treedesc[treename].planks_stair,
-					moretrees.treedesc[treename].planks_slab,
-					default.node_sound_wood_defaults()
-				)
+				if moretrees.enable_planks then
+					stairs.register_stair_and_slab(
+						"moretrees_"..treename.."_planks",
+						"moretrees:"..treename.."_planks",
+						{ snappy=1, choppy=2, oddly_breakable_by_hand=2, flammable=3 },
+						{ "moretrees_"..treename.."_wood.png" },
+						moretrees.treedesc[treename].planks_stair,
+						moretrees.treedesc[treename].planks_slab,
+						default.node_sound_wood_defaults()
+					)
+				end
 
 			end
 		end
 
-		if moretrees.enable_fences then
+		if moretrees.enable_planks and moretrees.enable_fences then
 			local planks_name = "moretrees:" .. treename .. "_planks"
 			local planks_tile = "moretrees_" .. treename .. "_wood.png"
 			default.register_fence("moretrees:" .. treename .. "_fence", {

--- a/settings.lua
+++ b/settings.lua
@@ -19,6 +19,12 @@ moretrees.enable_beech			= stg:get_bool("moretrees.enable_beech", false)
 --spawns tree on mapgen as saplings, legacy setting
 moretrees.spawn_saplings		= stg:get_bool("moretrees.spawn_saplings", true)
 
+--turn on/off plank variants of nodes; if disabled also disables stair and plank
+--variants depending on these planks *as well as the plank crafting recipe*;
+--useful for games that have only one plank type and a generic plank crafting
+--recipe
+moretrees.enable_planks			= stg:get_bool("moretrees.enable_planks", true)
+
 --turn on/off stair varients of nodes via moreblocks or the stair api
 moretrees.enable_stairs			= stg:get_bool("moretrees.enable_stairs", true)
 


### PR DESCRIPTION
Useful for games like Voxelgarden that have only one plank type with a generic plank crafting recipe.

Disabling the planks implicitly disables stair and fence variants depending on these planks as well as the log to plank crafting recipe.