### PR TITLE
[no squash] Disable jungletree generation when default isn't available

### DIFF
--- a/biome_defs.lua
+++ b/biome_defs.lua
@@ -1,74 +1,36 @@
 
 moretrees.beech_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 8,
-	seed_diff = 2,
-	rarity = 50,
-	max_count = 20,
 }
 
 moretrees.palm_biome = {
 	surface = xcompat.materials.sand,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 5,
-	seed_diff = 330,
 	min_elevation = -1,
 	max_elevation = 1,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 15,
 	near_nodes_count = 10,
-	temp_min = 0.25,
-	temp_max = -0.15,
-	rarity = 50,
-	max_count = 10,
 }
 
 moretrees.date_palm_biome = {
 	surface = xcompat.materials.desert_sand,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 339,
 	min_elevation = -1,
 	max_elevation = 10,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 20,
 	near_nodes_count = 100,
-	near_nodes_vertical = 20,
-	temp_min = -0.20,
-	humidity_max = 0.20,
-	rarity = 10,
-	max_count = 30,
 }
 
 moretrees.date_palm_biome_2 = {
 	surface = xcompat.materials.desert_sand,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 340,
 	min_elevation = 11,
 	max_elevation = 30,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 1,
 	near_nodes_count = 1,
-	near_nodes_vertical = 30,
-	temp_min = -0.20,
-	humidity_max = 0.20,
-	rarity = 10,
-	max_count = 30,
 }
 
 moretrees.apple_tree_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 331,
 	min_elevation = 1,
 	max_elevation = 10,
-	temp_min = 0.1,
-	temp_max = -0.15,
-	rarity = 75,
-	max_count = 5,
 	place_on = {xcompat.materials.dirt_with_grass},
 	biomes = {"deciduous_forest"},
 	fill_ratio = 0.0001,
@@ -76,73 +38,39 @@ moretrees.apple_tree_biome = {
 
 moretrees.oak_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 15,
-	seed_diff = 332,
 	min_elevation = 0,
 	max_elevation = 10,
-	temp_min = 0.4,
-	temp_max = 0.2,
-	rarity = 50,
-	max_count = 5,
 	fill_ratio = 0.0003
 }
 
 moretrees.sequoia_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 333,
 	min_elevation = 0,
 	max_elevation = 10,
-	temp_min = 1,
-	temp_max = -0.4,
-	rarity = 90,
-	max_count = 5,
 	fill_ratio = 0.0001,
 }
 
 moretrees.birch_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 5,
-	seed_diff = 334,
 	min_elevation = 10,
 	max_elevation = 15,
-	temp_min = 0.9,
-	temp_max = 0.3,
-	rarity = 50,
-	max_count = 10,
 	fill_ratio = 0.001,
 }
 
 moretrees.willow_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 337,
 	min_elevation = -5,
 	max_elevation = 5,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 15,
 	near_nodes_count = 5,
-	rarity = 75,
-	max_count = 5,
 }
 
 moretrees.rubber_tree_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 338,
 	min_elevation = -5,
 	max_elevation = 5,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 15,
 	near_nodes_count = 10,
-	temp_min = -0.15,
-	rarity = 75,
-	max_count = 10,
 }
 
 moretrees.jungletree_biome = {
@@ -154,157 +82,75 @@ moretrees.jungletree_biome = {
 		"woodsoils:grass_with_leaves_2",
 		"default:dirt_with_rainforest_litter",
 	},
-	avoid_nodes = {"moretrees:jungletree_trunk"},
-	max_count = 12,
-	avoid_radius = 3,
-	rarity = 85,
-	seed_diff = 329,
 	min_elevation = 1,
 	near_nodes = minetest.get_modpath("default") and {"default:jungletree"} or nil,
-	near_nodes_size = minetest.get_modpath("default") and 6 or nil,
-	near_nodes_vertical = minetest.get_modpath("default") and 2 or nil,
 	near_nodes_count = minetest.get_modpath("default") and 1 or nil,
-	plantlife_limit = -0.9,
 	biomes = {"rainforest", "rainforest_swamp"},
 }
 
 moretrees.spruce_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 335,
 	min_elevation = 20,
-	temp_min = 0.9,
-	temp_max = 0.7,
-	rarity = 50,
-	max_count = 5,
 }
 
 moretrees.cedar_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 336,
 	min_elevation = 0,  --Added to solve an issue where cedar trees would sometimes spawn deep underground
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 15,
 	near_nodes_count = 5,
-	rarity = 50,
-	max_count = 10,
 }
 
 
 -- Poplar requires a lot of water.
 moretrees.poplar_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 6,
-	seed_diff = 341,
 	min_elevation = 0,
 	max_elevation = 50,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 15,
-	near_nodes_vertical = 5,
 	near_nodes_count = 1,
-	humidity_min = -0.7,
-	humidity_max = -1,
-	rarity = 50,
-	max_count = 15,
 }
 
--- The humidity requirement it quite restrictive (apparently).
 -- Spawn an occasional poplar elsewhere.
 moretrees.poplar_biome_2 = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 6,
-	seed_diff = 341,
 	min_elevation = 0,
 	max_elevation = 50,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 15,
-	near_nodes_vertical = 4,
 	near_nodes_count = 10,
-	humidity_min = 0.1,
-	humidity_max = -0.6,
-	rarity = 50,
-	max_count = 1,
 }
 
 -- Subterranean lakes provide enough water for poplars to grow
 moretrees.poplar_biome_3 = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 6,
-	seed_diff = 342,
 	min_elevation = 0,
 	max_elevation = 50,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 1,
-	near_nodes_vertical = 25,
 	near_nodes_count = 1,
-	humidity_min = -0.5,
-	humidity_max = -1,
-	rarity = 0,
-	max_count = 30,
 }
 
 moretrees.poplar_small_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 4,
-	seed_diff = 343,
 	min_elevation = 0,
 	max_elevation = 50,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 10,
-	near_nodes_vertical = 5,
 	near_nodes_count = 1,
-	humidity_min = -0.7,
-	humidity_max = -1,
-	rarity = 50,
-	max_count = 10,
 }
 
 moretrees.poplar_small_biome_2 = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 4,
-	seed_diff = 343,
 	min_elevation = 0,
 	max_elevation = 50,
 	near_nodes = {xcompat.materials.water_source},
-	near_nodes_size = 10,
-	near_nodes_vertical = 4,
 	near_nodes_count = 5,
-	humidity_min = 0.1,
-	humidity_max = -0.6,
-	rarity = 50,
-	max_count = 3,
 }
 
 
 moretrees.fir_biome = {
 	surface = xcompat.materials.dirt_with_grass,
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 359,
 	min_elevation = 25,
-	temp_min = 0.9,
-	temp_max = 0.3,
-	rarity = 50,
-	max_count = 10,
 }
 
 moretrees.fir_biome_snow = {
 	surface = {"snow:dirt_with_snow", "snow:snow"},
 	below_nodes = {xcompat.materials.dirt, xcompat.materials.dirt_with_grass, "snow:dirt_with_snow"},
-	avoid_nodes = moretrees.avoidnodes,
-	avoid_radius = 10,
-	seed_diff = 359,
-	rarity = 50,
-	max_count = 10,
-	check_air = false,
-	delete_above = true,
-	spawn_replace_node = true
 }

--- a/init.lua
+++ b/init.lua
@@ -163,7 +163,9 @@ minetest.register_decoration(translate_biome_defs(moretrees.rubber_tree_biome, "
 minetest.register_decoration(translate_biome_defs(moretrees.willow_biome, "willow"))
 minetest.register_decoration(translate_biome_defs(moretrees.birch_biome, "birch"))
 minetest.register_decoration(translate_biome_defs(moretrees.spruce_biome, "spruce"))
-minetest.register_decoration(translate_biome_defs(moretrees.jungletree_biome, "jungletree"))
+if minetest.get_modpath("default") then
+	minetest.register_decoration(translate_biome_defs(moretrees.jungletree_biome, "jungletree"))
+end
 minetest.register_decoration(translate_biome_defs(moretrees.fir_biome, "fir", 1))
 if minetest.get_modpath("snow") then
 	minetest.register_decoration(translate_biome_defs(moretrees.fir_biome_snow, "fir", 2))


### PR DESCRIPTION
Resolves #42 and maybe #12.

- Remove unused params from biome_defs (I kept `biomes` due to https://github.com/mt-mods/moretrees/blob/3e424b2797723640a4c915da664f30fbd9e80934/init.lua#L141)
- Disable jungletree generation when default isn't available

Might make sense to generate jungletrees when the game provides somethink like `xcompat.materials.jungletree` (not implemented in xcompat yet). Then we could nuke the copied node completely and alias it when default is loaded.