### PR TITLE
Make all trees spawn again

### DIFF
--- a/biome_defs.lua
+++ b/biome_defs.lua
@@ -1,30 +1,45 @@
 
+-- TODO
+-- Use biomes in the decoration definition depending on their heat_point humidity_point
+-- instead of spawning it with a rather low fill_ratio everywhere
+local ratio_abundant =  0.001
+local ratio_common =    0.0005
+local ratio_normal =    0.0003
+local ratio_uncommon =  0.0002
+local ratio_rare =      0.0001
+local ratio_very_rare = 0.00003
+
+local coniferous_place_on = {
+	xcompat.materials.dirt_with_grass,
+	"default:dirt_with_coniferous_litter"
+}
+
 moretrees.beech_biome = {
 	place_on = xcompat.materials.dirt_with_grass,
+	fill_ratio = ratio_normal,
 }
 
 moretrees.palm_biome = {
 	place_on = xcompat.materials.sand,
 	min_elevation = -1,
 	max_elevation = 1,
-	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 10,
+	fill_ratio = ratio_abundant,
 }
 
 moretrees.date_palm_biome = {
 	place_on = xcompat.materials.desert_sand,
 	min_elevation = -1,
-	max_elevation = 10,
-	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 100,
+	max_elevation = 8,
+	fill_ratio = ratio_common,
 }
 
 moretrees.date_palm_biome_2 = {
 	place_on = xcompat.materials.desert_sand,
-	min_elevation = 11,
+	min_elevation = 9,
 	max_elevation = 30,
 	spawn_by = {xcompat.materials.water_source},
 	num_spawn_by = 1,
+	fill_ratio = ratio_abundant,
 }
 
 moretrees.apple_tree_biome = {
@@ -32,44 +47,42 @@ moretrees.apple_tree_biome = {
 	min_elevation = 1,
 	max_elevation = 10,
 	biomes = {"deciduous_forest"},
-	fill_ratio = 0.0001,
+	fill_ratio = ratio_rare,
 }
 
 moretrees.oak_biome = {
 	place_on = xcompat.materials.dirt_with_grass,
 	min_elevation = 0,
 	max_elevation = 10,
-	fill_ratio = 0.0003
+	fill_ratio = ratio_normal,
 }
 
 moretrees.sequoia_biome = {
 	place_on = xcompat.materials.dirt_with_grass,
 	min_elevation = 0,
 	max_elevation = 10,
-	fill_ratio = 0.0001,
+	fill_ratio = ratio_rare,
 }
 
 moretrees.birch_biome = {
 	place_on = xcompat.materials.dirt_with_grass,
 	min_elevation = 10,
 	max_elevation = 15,
-	fill_ratio = 0.001,
+	fill_ratio = ratio_common,
 }
 
 moretrees.willow_biome = {
 	place_on = xcompat.materials.dirt_with_grass,
 	min_elevation = -5,
 	max_elevation = 5,
-	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 5,
+	fill_ratio = ratio_uncommon,
 }
 
 moretrees.rubber_tree_biome = {
 	place_on = xcompat.materials.dirt_with_grass,
 	min_elevation = -5,
-	max_elevation = 5,
-	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 10,
+	max_elevation = 8,
+	fill_ratio = ratio_normal,
 }
 
 moretrees.jungletree_biome = {
@@ -88,15 +101,15 @@ moretrees.jungletree_biome = {
 }
 
 moretrees.spruce_biome = {
-	place_on = xcompat.materials.dirt_with_grass,
+	place_on = coniferous_place_on,
 	min_elevation = 20,
+	fill_ratio = ratio_uncommon,
 }
 
 moretrees.cedar_biome = {
-	place_on = xcompat.materials.dirt_with_grass,
+	place_on = coniferous_place_on,
 	min_elevation = 0,  --Added to solve an issue where cedar trees would sometimes spawn deep underground
-	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 5,
+	fill_ratio = ratio_rare,
 }
 
 
@@ -106,7 +119,8 @@ moretrees.poplar_biome = {
 	min_elevation = 0,
 	max_elevation = 50,
 	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 1,
+	num_spawn_by = 3,
+	fill_ratio = ratio_abundant,
 }
 
 -- Spawn an occasional poplar elsewhere.
@@ -114,17 +128,17 @@ moretrees.poplar_biome_2 = {
 	place_on = xcompat.materials.dirt_with_grass,
 	min_elevation = 0,
 	max_elevation = 50,
-	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 10,
+	fill_ratio = ratio_very_rare,
 }
 
 -- Subterranean lakes provide enough water for poplars to grow
 moretrees.poplar_biome_3 = {
 	place_on = xcompat.materials.dirt_with_grass,
-	min_elevation = 0,
-	max_elevation = 50,
+	min_elevation = -50,
+	max_elevation = 0,
 	spawn_by = {xcompat.materials.water_source},
-	num_spawn_by = 1,
+	num_spawn_by = 3,
+	fill_ratio = ratio_abundant,
 }
 
 moretrees.poplar_small_biome = {
@@ -133,6 +147,7 @@ moretrees.poplar_small_biome = {
 	max_elevation = 50,
 	spawn_by = {xcompat.materials.water_source},
 	num_spawn_by = 1,
+	fill_ratio = ratio_normal,
 }
 
 moretrees.poplar_small_biome_2 = {
@@ -141,15 +156,18 @@ moretrees.poplar_small_biome_2 = {
 	max_elevation = 50,
 	spawn_by = {xcompat.materials.water_source},
 	num_spawn_by = 5,
+	fill_ratio = ratio_abundant,
 }
 
 
 moretrees.fir_biome = {
-	place_on = xcompat.materials.dirt_with_grass,
+	place_on = coniferous_and_snow_place_on,
 	min_elevation = 25,
+	fill_ratio = ratio_normal,
 }
 
 moretrees.fir_biome_snow = {
 	place_on = {"snow:dirt_with_snow", "snow:snow"},
 	below_nodes = {xcompat.materials.dirt, xcompat.materials.dirt_with_grass, "snow:dirt_with_snow"},
+	fill_ratio = ratio_normal,
 }

--- a/biome_defs.lua
+++ b/biome_defs.lua
@@ -161,7 +161,7 @@ moretrees.poplar_small_biome_2 = {
 
 
 moretrees.fir_biome = {
-	place_on = coniferous_and_snow_place_on,
+	place_on = coniferous_place_on,
 	min_elevation = 25,
 	fill_ratio = ratio_normal,
 }


### PR DESCRIPTION
Most spawn by water source trees (including rubber trees) will **never** spawn.
(`spawn_by` and `num_spawn_by` is only for the 8 neighboring nodes at y coordinate -1.)
This is horrible if you actually want to use this mod, it has been a long time since I last did.
Fixes #48 #33 and forum posts.

Only for trees that grow in water (not even for palms), it would make sense to use spawn by water.
So I removed most of it. For palms, restricting `y_max` works better.

I tested it (in MTG) and found every tree in a reasonable about of time. Also, the trees are not too common, imo.

It's not perfect, a better solution would use biomes in the decoration definition depending on their `heat_point` and `humidity_point`, but I don't want to figure out numbers and deal with compatibility problems.
So with this PR at least all trees (including rubber trees) will spawn again.

Moreover, note that the trees still don't spawn on `default:dirt_with_dry_grass`, `default:dry_dirt_with_dry_grass` and `default:dirt_with_snow` (the latter would require special snow covered saplings.)
Feel free to make improvements